### PR TITLE
member expressions and aliasing

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,6 +78,32 @@ export default function undebug() {
         ) {
           instances.push(p.node.id.name)
           p.remove()
+        } else if (
+          p.node.init.type === 'Identifier' &&
+          instances.includes(p.node.init.name)
+        ) {
+          // Add the alias to our instances array
+          instances.push(p.node.id.name)
+          p.remove()
+        }
+      },
+      MemberExpression(p, state) {
+        const instances = /** @type {string[]} */ (
+          state.undebugInstances || (state.undebugInstances = [])
+        )
+
+        // Check if accessing property on a debug instance
+        // e.g. log.enabled, log.color, log.namespace, etc.
+        if (
+          p.node.type === 'MemberExpression' &&
+          p.node.object.type === 'Identifier' &&
+          instances.includes(p.node.object.name)
+        ) {
+          // Replace the member expression with undefined
+          p.replaceWith({
+            type: 'Identifier',
+            name: 'undefined'
+          })
         }
       }
     }

--- a/index.js
+++ b/index.js
@@ -82,7 +82,6 @@ export default function undebug() {
           p.node.init.type === 'Identifier' &&
           instances.includes(p.node.init.name)
         ) {
-          // Add the alias to our instances array
           instances.push(p.node.id.name)
           p.remove()
         } else if (
@@ -90,7 +89,6 @@ export default function undebug() {
           p.node.init.object.type === 'Identifier' &&
           instances.includes(p.node.init.object.name)
         ) {
-          // Add the method reference to our instances array
           instances.push(p.node.id.name)
           p.remove()
         }
@@ -104,12 +102,12 @@ export default function undebug() {
           p.node.object.type === 'Identifier' &&
           instances.includes(p.node.object.name)
         ) {
-          // Check if this member expression is being used as a function call
           if (
+            // Check if this member expression is being used as a function call
+            // and remove the whole call. e.g. log.log("").
             p.parent.type === 'CallExpression' &&
             p.parent.callee === p.node
           ) {
-            // If it's a method call like log.log(""), remove the whole call
             p.parentPath.remove()
           } else {
             // Otherwise accessing property on a debug instance, replace with

--- a/test.js
+++ b/test.js
@@ -58,14 +58,6 @@ test('babel-plugin-undebug', function () {
 
   assert.equal(
     transform(
-      'import {debug as d} from "debug"; var a = d("a"); console.log("is a.enabled?", a.enabled)'
-    ),
-    'console.log("is a.enabled?", undefined);',
-    'should replace member expressions with undefined'
-  )
-
-  assert.equal(
-    transform(
       'import {debug as d} from "debug"; var a = d("a"); var b = a; b("c");'
     ),
     '',
@@ -73,11 +65,41 @@ test('babel-plugin-undebug', function () {
   )
 
   assert.equal(
+    transform('import {debug as d} from "debug"; var a = d("a"); a.log("b");'),
+    '',
+    'should remove member property function calls'
+  )
+
+  assert.equal(
+    transform(
+      'import {debug as d} from "debug"; var a = d("a"); console.log("is a.enabled?", a.enabled)'
+    ),
+    'console.log("is a.enabled?", undefined);',
+    'should replace member properties with undefined'
+  )
+
+  assert.equal(
     transform(
       'import {debug as d} from "debug"; var a = d("a"); var b = a; console.log("is b.enabled?", b.enabled)'
     ),
     'console.log("is b.enabled?", undefined);',
-    'should replace aliased member expressions with undefined'
+    'should replace aliased member properties with undefined'
+  )
+
+  assert.equal(
+    transform(
+      'import {debug as d} from "debug"; var a = d("a"); var b = a.log; b("c");'
+    ),
+    '',
+    'should remove aliased member property function calls'
+  )
+
+  assert.equal(
+    transform(
+      'import {debug as d} from "debug"; var a = d("a"); var b = a; b.log("c");'
+    ),
+    '',
+    'should remove alias that uses a member property'
   )
 })
 

--- a/test.js
+++ b/test.js
@@ -55,6 +55,30 @@ test('babel-plugin-undebug', function () {
     'a(1);\nb = 1 + 1;\nc()();\nd.e();\nf("g");',
     'should not remove other calls'
   )
+
+  assert.equal(
+    transform(
+      'import {debug as d} from "debug"; var a = d("a"); console.log("is a.enabled?", a.enabled)'
+    ),
+    'console.log("is a.enabled?", undefined);',
+    'should replace member expressions with undefined'
+  )
+
+  assert.equal(
+    transform(
+      'import {debug as d} from "debug"; var a = d("a"); var b = a; b("c");'
+    ),
+    '',
+    'should support aliased callers'
+  )
+
+  assert.equal(
+    transform(
+      'import {debug as d} from "debug"; var a = d("a"); var b = a; console.log("is b.enabled?", b.enabled)'
+    ),
+    'console.log("is b.enabled?", undefined);',
+    'should replace aliased member expressions with undefined'
+  )
 })
 
 /**


### PR DESCRIPTION
Handle member expressions being used on the debug instance. For example:
```javascript
import { debug as d } from "debug";
var a = d("a");
console.log("is a.enabled?", a.enabled); // replaced with console.log("is a.enabled?", undefined)
```

Handle aliasing.  For example:
```javascript
import { debug as d } from "debug";
var a = d("a");
var b = a; // aliased
b("c");
// all the lines above should be removed
```

Handle member properties that are functions being called. For example:
```javascript
import { debug as d } from "debug";
var a = d("a");
a.log("b");
// all the lines above should be removed
```

Handle member properties that are functions being aliased. For example:
```javascript
import { debug as d } from "debug";
var a = d("a");
var b = a.log;
b("c");
// all the lines above should be removed
```